### PR TITLE
Allow reference variables

### DIFF
--- a/mix-env-file.js
+++ b/mix-env-file.js
@@ -21,7 +21,7 @@ mix.extend(
                 let reference = /\$\{([^\}]+)\}/;
 
                 for (let k in envConfig) {
-                    let ref = envConfig[k].match(reference)
+                    let ref = envConfig[k].match(reference);
                     if (ref && ref[1] && envConfig[ref[1]]) {
                         process.env[k] = envConfig[ref[1]];
                     } else {

--- a/mix-env-file.js
+++ b/mix-env-file.js
@@ -17,9 +17,16 @@ mix.extend(
                     console.error('Unable to parse env file at ' + file + '\r\nPlease make sure this file exists and is formatted correctly.');
                     process.exit();
                 }
+                
+                let reference = /\$\{([^\}]+)\}/;
 
                 for (let k in envConfig) {
-                    process.env[k] = envConfig[k];
+                    let ref = envConfig[k].match(reference)
+                    if (ref && ref[1] && envConfig[ref[1]]) {
+                        process.env[k] = envConfig[ref[1]];
+                    } else {
+                        process.env[k] = envConfig[k];
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change will enable the plugin to parse reference variables
ie.
```bash
PUSHER_APP_KEY=abc123abc
MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
```